### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The webhook officially supports **Kubernetes version _1.19_** and higher, and ha
 ```
   helm repo add datree-webhook https://datreeio.github.io/admission-webhook-datree/
   helm repo update
-  helm install datree-webhook datree-webhook/datree-admission-webhook --create-namespace --set datree.token=<DATREE_TOKEN>
+  helm install datree-webhook datree-webhook/datree-admission-webhook --set datree.token=<DATREE_TOKEN>
 ```
 
 For more information see [Datree webhook Helm chart](https://github.com/datreeio/admission-webhook-datree/tree/gh-pages).


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1P6WYdUh3XGsoEBR48x8fIobf83L04aA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=OLIby5f)
removed --create-namespace from helm install command. The helm chart currently doesn't support Helm namespaces.