### PR TITLE
feat: Security context for OpenShift

### DIFF
--- a/charts/datree-admission-webhook/templates/namespace-post-delete.yaml
+++ b/charts/datree-admission-webhook/templates/namespace-post-delete.yaml
@@ -27,6 +27,7 @@ spec:
         - name: kubectl-label
           image: "{{ .Values.hooks.image.repository }}:{{ .Values.hooks.image.tag }}"
           imagePullPolicy: {{.Values.hooks.image.pullPolicy}}
+          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}          
           command:
             - sh
             - "-c"

--- a/charts/datree-admission-webhook/templates/namespace-post-install.yaml
+++ b/charts/datree-admission-webhook/templates/namespace-post-install.yaml
@@ -28,6 +28,7 @@ spec:
         - name: kubectl-label
           image: "{{ .Values.hooks.image.repository }}:{{ .Values.hooks.image.tag }}"
           imagePullPolicy: {{.Values.hooks.image.pullPolicy}}
+          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}          
           args:
             - label
             - ns

--- a/charts/datree-admission-webhook/templates/wait-server-ready-post-install.yaml
+++ b/charts/datree-admission-webhook/templates/wait-server-ready-post-install.yaml
@@ -27,6 +27,7 @@ spec:
       - name: kubectl-client
         image: "{{ .Values.hooks.image.repository }}:{{ .Values.hooks.image.tag }}"
         imagePullPolicy: {{.Values.hooks.image.pullPolicy}}
+        securityContext: {{- toYaml .Values.securityContext | nindent 12 }}        
         command:
           - sh
           - "-c"

--- a/charts/datree-admission-webhook/values.yaml
+++ b/charts/datree-admission-webhook/values.yaml
@@ -56,11 +56,10 @@ image:
   pullPolicy: Always
 # Security context for the containers
 securityContext:
-## OpenShift SecurityContext
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   runAsNonRoot: true
-  # runAsUser: 25000 > OpenShift assigns a unique UID per namespace
+  runAsUser: 25000
   capabilities:
     drop: ["ALL"]
   seccompProfile:

--- a/charts/datree-admission-webhook/values.yaml
+++ b/charts/datree-admission-webhook/values.yaml
@@ -56,10 +56,15 @@ image:
   pullPolicy: Always
 # Security context for the containers
 securityContext:
+## OpenShift SecurityContext
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   runAsNonRoot: true
-  runAsUser: 25000
+  # runAsUser: 25000 > OpenShift assigns a unique UID per namespace
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault  
 resources: {}
 # limits:
 #   cpu: 200m


### PR DESCRIPTION
## Description
OpenShift does not allow pods to run without a proper seccontext set.
The pre/post jobs had no seccontext set, and the pods failed to run.

I've added the missing seccontext for the jobs and provided the SecContext changes in the `values.yaml`.

Note:
OpenShift generates a unique UID per namespace. It is recommended to leave it instead of providing a hardcoded UID `25000.` 