### PR TITLE
fix: helm values and validation

### DIFF
--- a/charts/datree-admission-webhook/values.schema.json
+++ b/charts/datree-admission-webhook/values.schema.json
@@ -32,8 +32,7 @@
       "properties": {
         "token": {
           "title": "The token Schema",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "clusterName": {
           "title": "The clusterName Schema",

--- a/charts/datree-admission-webhook/values.schema.json
+++ b/charts/datree-admission-webhook/values.schema.json
@@ -37,7 +37,7 @@
         },
         "clusterName": {
           "title": "The clusterName Schema",
-          "type": "string",
+          "type": ["string", "null"],
           "default": ""
         },
         "scanIntervalHours": {
@@ -52,7 +52,7 @@
         },
         "policy": {
           "title": "The policy Schema",
-          "type": "string",
+          "type": ["string", "null"],
           "default": ""
         }
       }
@@ -62,7 +62,6 @@
       "type": "object",
       "required": [
         "repository",
-        "tag",
         "pullPolicy"
       ],
       "properties": {
@@ -73,7 +72,7 @@
         },
         "tag": {
           "title": "The tag Schema",
-          "type": "string",
+          "type": ["string", "null"],
           "default": ""
         },
         "pullPolicy": {
@@ -96,8 +95,7 @@
           "type": "object",
           "required": [
             "repository",
-            "pullPolicy",
-            "tag"
+            "pullPolicy"
           ],
           "properties": {
             "repository": {
@@ -113,7 +111,7 @@
             },
             "tag": {
               "title": "The tag Schema",
-              "type": "string",
+              "type": ["string", "null"],
               "default": ""
             }
           }

--- a/charts/datree-admission-webhook/values.yaml
+++ b/charts/datree-admission-webhook/values.yaml
@@ -5,9 +5,9 @@ namespace: ""
 # The number of Datree webhook-server replicas to deploy for the webhook.
 replicaCount: 2
 # Additional labels to add to all resources.
-customLabels: {}
+customLabels: { }
 # Additional annotations to add to all resources.
-customAnnotations: {}
+customAnnotations: { }
 # Create ClusterRoles, ClusterRoleBindings, and ServiceAccount for datree-webhook-server
 rbac:
   serviceAccount:
@@ -23,7 +23,7 @@ rbac:
 datree:
   # It is required to provide either the token or the existingSecret containing the token for correct functionality.
   # The token used to link the CLI to your dashboard. (string)
-  token: <DATREE_TOKEN>
+  token:
   # The token may also be provided via secret, note if the existingSecret is provided the token field above is ignored.
   existingSecret:
     name: "" # Name of the secret containing the datree token (string)
@@ -65,22 +65,22 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 25000
   capabilities:
-    drop: ["ALL"]
+    drop: [ "ALL" ]
   seccompProfile:
     type: RuntimeDefault
-resources: {}
+resources: { }
 # limits:
 #   cpu: 200m
 #   memory: 256Mi
 # requests:
 #   cpu: 200m
 #   memory: 48Mi
-nodeSelector: {}
-affinity: {}
-tolerations: []
+nodeSelector: { }
+affinity: { }
+tolerations: [ ]
 clusterScanner:
-  resources: {}
-  annotations: {}
+  resources: { }
+  annotations: { }
   # Create ClusterRoles, ClusterRoleBindings, and ServiceAccount for datree-webhook-server
   rbac:
     serviceAccount:


### PR DESCRIPTION
- changed `token` to `null` by default, so users that don't set it fail the installation step
- changed `datree.clusterName`, `datree.policy`, `image.tag`, `clusterScanner.image.tag` to be nullable. this way users can install the helm chart without setting those values

running `helm install -n datree datree-webhook ./charts/datree-admission-webhook --debug`, this is the output:
**before:**
![Screenshot 2023-05-10 at 13 03 19](https://github.com/datreeio/admission-webhook-datree/assets/39004075/2f1ba9b8-221d-4168-90ae-d2abbaf89719)

**after:**
![Screenshot 2023-05-10 at 13 03 38](https://github.com/datreeio/admission-webhook-datree/assets/39004075/29701fc1-4ff1-4f39-8e63-1fd870f60c51)
