### PR TITLE
feat: add annotation to deployment spec that will make the deployment roolout on helm upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,15 +35,8 @@ helm-install-local-in-minikube:
 	./scripts/build-docker-image.sh && \
 	helm install -n datree datree-webhook ./charts/datree-admission-webhook \
 	--create-namespace \
+	-f ./internal/fixtures/values.dev.yaml \
 	--set datree.token="${DATREE_TOKEN}" \
-	--set datree.clusterName="minikube" \
-	--set datree.policy="Starter" \
-	--set clusterScanner.image.repository="datree/cluster-scanner-staging" \
-	--set clusterScanner.image.tag="latest" \
-	--set image.repository="webhook-server" \
-	--set image.pullPolicy="Never" \
-	--set image.tag="latest" \
-	--set replicaCount=1 \
 	--set scanJob.ttlSecondschange-ping-uninstall-url-to-productionFinished=100 \
 	--debug && \
 	make change-ping-uninstall-url-to-production

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,22 @@ helm-install-local-in-minikube:
 	make change-ping-uninstall-url-to-production
 
 helm-upgrade-local:
-	helm upgrade -n datree datree-webhook ./charts/datree-admission-webhook --reuse-values --set datree.enforce="true"
+	make change-ping-uninstall-url-to-staging && \
+	eval $(minikube docker-env) && \
+	helm upgrade -n datree datree-webhook ./charts/datree-admission-webhook \
+	--set datree.token="${DATREE_TOKEN}" \
+	--set datree.clusterName="minikube" \
+	--set datree.policy="Starter" \
+	--set clusterScanner.image.repository="datree/cluster-scanner-staging" \
+	--set clusterScanner.image.tag="latest" \
+	--set image.repository="webhook-server" \
+	--set image.pullPolicy="Never" \
+	--set image.tag="latest" \
+	--set replicaCount=1 \
+	--set datree.enforce="true" \
+	--set scanJob.ttlSecondschange-ping-uninstall-url-to-productionFinished=100 \
+	--debug && \
+	make change-ping-uninstall-url-to-production
 
 helm-uninstall:
 	helm uninstall -n datree datree-webhook

--- a/Makefile
+++ b/Makefile
@@ -52,16 +52,8 @@ helm-upgrade-local:
 	make change-ping-uninstall-url-to-staging && \
 	eval $(minikube docker-env) && \
 	helm upgrade -n datree datree-webhook ./charts/datree-admission-webhook \
+	-f ./internal/fixtures/values.dev.yaml \
 	--set datree.token="${DATREE_TOKEN}" \
-	--set datree.clusterName="minikube" \
-	--set datree.policy="Starter" \
-	--set clusterScanner.image.repository="datree/cluster-scanner-staging" \
-	--set clusterScanner.image.tag="latest" \
-	--set image.repository="webhook-server" \
-	--set image.pullPolicy="Never" \
-	--set image.tag="latest" \
-	--set replicaCount=1 \
-	--set datree.enforce="true" \
 	--set scanJob.ttlSecondschange-ping-uninstall-url-to-productionFinished=100 \
 	--debug && \
 	make change-ping-uninstall-url-to-production

--- a/charts/datree-admission-webhook/templates/cluster-scanner.yaml
+++ b/charts/datree-admission-webhook/templates/cluster-scanner.yaml
@@ -74,9 +74,11 @@ spec:
     metadata:
       labels: {{ include "datree.labels" . | nindent 8 }}
         app: "datree-cluster-scanner-server"
-      {{- with .Values.customAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      annotations:
+        roolout: {{ randAlphaNum 5 | quote }}
+        {{- with .Values.customAnnotations }}
+        {{ toYaml . }}
+        {{- end}}
     spec:
       {{- if .Values.nodeSelector }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/charts/datree-admission-webhook/templates/deployment.yaml
+++ b/charts/datree-admission-webhook/templates/deployment.yaml
@@ -20,9 +20,11 @@ spec:
     metadata:
       labels: {{ include "datree.labels" . | nindent 8 }}
         app: "datree-webhook-server"
-      {{- with .Values.customAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      annotations:
+        roolout: {{ randAlphaNum 5 | quote }}
+        {{- with .Values.customAnnotations }}
+        {{ toYaml . }}
+        {{- end}}
     spec:
       {{- if .Values.nodeSelector }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/internal/fixtures/values.dev.yaml
+++ b/internal/fixtures/values.dev.yaml
@@ -1,0 +1,127 @@
+# for autocompletion in VS Code
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/admission-webhook-datree/main/charts/datree-admission-webhook/values.schema.json
+
+# Default values for datree-admission-webhook.
+
+# The name of the namespace all resources will be created in, if not specified in the release.
+namespace: ""
+# The number of Datree webhook-server replicas to deploy for the webhook.
+replicaCount: 1
+# Additional labels to add to all resources.
+customLabels: { }
+# Additional annotations to add to all resources.
+customAnnotations: { }
+# Create ClusterRoles, ClusterRoleBindings, and ServiceAccount for datree-webhook-server
+rbac:
+  serviceAccount:
+    # Create the ServiceAccount
+    create: true
+    # The ServiceAccount name
+    name: datree-webhook-server
+  clusterRole:
+    # Create the ClusterRole
+    create: true
+    # The ClusterRole name
+    name: datree-webhook-server-cluster-role
+datree:
+  # It is required to provide either the token or the existingSecret containing the token for correct functionality.
+  # The token used to link the CLI to your dashboard. (string)
+  token:
+  # The token may also be provided via secret, note if the existingSecret is provided the token field above is ignored.
+  existingSecret:
+    name: "" # Name of the secret containing the datree token (string)
+    key: "" # Key within a given secret that contains the token (string)
+  # Display 'How to Fix' link for failed rules in output. (boolean ,optional)
+  verbose:
+  # The format output of the policy check results: yaml, json, xml, simple, JUnit. (string ,optional)
+  output:
+  # Don’t send policy checks metadata to the backend. (boolean ,optional)
+  noRecord:
+  # The name of the cluster link for cluster name in your dashboard. (string ,optional)
+  clusterName: "minikube"
+  # How often should the scan run in hours. (int, optional, default: 1 )
+  scanIntervalHours: 1
+
+  # If false, the webhook will be configured from the dashboard, otherwise it will be configured from here.
+  # Affected configurations: policy, enforce, customSkipList.
+  configFromHelm: false
+  # The name of the policy to check, e.g: staging. (string, optional)
+  policy: "Starter"
+  # Block resources that fail the policy check. (boolean ,optional)
+  enforce:
+  # Excluded resources from policy checks. ("namespace;kind;name" ,optional)
+  customSkipList:
+    # Recommended resources to exclude from your policy checks.
+    - "(.*);(.*);(^aws-node.*)" # skip aws-node-xxxxx resources in all namespaces, specifically skips EKS vpc-cni addon.
+    - "(.*);(.*);(^aws-123.*)" # skip aws-node-xxxxx resources in all namespaces, specifically skips EKS vpc-cni addon.
+# The Datree webhook-server image to use.
+image:
+  # Image repository
+  repository: webhook-server
+  # Image tag
+  tag: latest
+  # Image pull policy
+  pullPolicy: Never
+# Security context for the containers
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 25000
+  capabilities:
+    drop: [ "ALL" ]
+  seccompProfile:
+    type: RuntimeDefault
+resources: { }
+# limits:
+#   cpu: 200m
+#   memory: 256Mi
+# requests:
+#   cpu: 200m
+#   memory: 48Mi
+nodeSelector: { }
+affinity: { }
+tolerations: [ ]
+clusterScanner:
+  resources: { }
+  annotations: { }
+  # Create ClusterRoles, ClusterRoleBindings, and ServiceAccount for datree-webhook-server
+  rbac:
+    serviceAccount:
+      # Create the ServiceAccount
+      create: true
+      # The ServiceAccount name
+      name: cluster-scanner-service-account
+    clusterRole:
+      # Create the ClusterRole
+      create: true
+      # The ClusterRole name
+      name: cluster-scanner-role
+    clusterRoleBinding:
+      name: cluster-scanner-role-binding
+  image:
+    # Image repository
+    repository: datree/cluster-scanner-staging
+    pullPolicy: Never
+    # Image tag
+    tag: latest
+    # limits:
+    #   cpu: 1000m
+    #   memory: 1048Mi
+    # requests:
+    #   cpu: 200m
+    #   memory: 256Mi
+# During install Datree run two hooks: pre-install and pre-delete.
+# `datree-label-namespaces-hook-post-install` - Helm hook that run after the chart is installed and label namespaces with admission.datree/validate=skip
+# `datree-wait-server-ready-hook-post-install` - Helm hook that run after the chart is awaits for the webhook-server to be ready
+hooks:
+  # The timeout time the hook will wait for the webhook-server is ready.
+  timeoutTime:
+  ttlSecondsAfterFinished:
+  # The image for running kubectl commands
+  image:
+    repository: clastix/kubectl
+    tag: v1.25
+    pullPolicy: IfNotPresent
+validatingWebhookConfiguration:
+  failurePolicy: Ignore


### PR DESCRIPTION
for reference:
https://v3.helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments

we mostly using it to make datree deployments aligned with datree configmap