### PR TITLE
refactor: fix tilt hot reload for webhook-server

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -55,7 +55,7 @@ def debugging():
     )
 
 def hot_reload():
-    docker_build('webhook-server', './', dockerfile = './Dockerfile.hotReload.tilt',
+    docker_build('webhook-server', './', dockerfile = './Dockerfile',
         build_args={
             "BUILD_ENVIRONMENT":"staging",
             "WEBHOOK_VERSION":"0.0.1",
@@ -63,7 +63,7 @@ def hot_reload():
     )
 
 
-    docker_build('datree/cluster-scanner-staging', '../cluster-scanner', dockerfile = '../cluster-scanner/Dockerfile.hotReload.tilt',
+    docker_build('datree/cluster-scanner-staging', '../cluster-scanner', dockerfile = '../cluster-scanner/Dockerfile',
         build_args={
             "BUILD_ENVIRONMENT":"staging",
             "SCANNER_VERSION":"0.0.1",

--- a/Tiltfile
+++ b/Tiltfile
@@ -55,7 +55,7 @@ def debugging():
     )
 
 def hot_reload():
-    docker_build('webhook-server', '.', dockerfile = './Dockerfile.hotReload.tilt',
+    docker_build('webhook-server', './', dockerfile = './Dockerfile.hotReload.tilt',
         build_args={
             "BUILD_ENVIRONMENT":"staging",
             "WEBHOOK_VERSION":"0.0.1",

--- a/Tiltfile
+++ b/Tiltfile
@@ -53,29 +53,22 @@ def debugging():
         name='cluster-scanner - restart port-forwarding',
         serve_cmd='bash ./tilt/scripts/restart-port-forwarding.sh "datree-cluster-scanner-server" "cluster-scanner debugging"',
     )
-load('ext://restart_process', 'docker_build_with_restart')
+
 def hot_reload():
-    compile_admission_webhook = 'CGO_ENABLED=0 GOOS=linux go build -tags staging -ldflags="-X github.com/datreeio/admission-webhook-datree/pkg/config.WebhookVersion=0.0.1" -o build/webhook-datree ./'
-    local_resource(
-        name="build-admission-webhook",
-        cmd=compile_admission_webhook,
-        deps=['./main.go'])
-    
-    docker_build_with_restart('webhook-server', './', dockerfile = './Dockerfile.hotReload.tilt', entrypoint="/app/build/webhook-datree",
-    live_update=[
-        sync('./build/webhook-datree', '/app/build'),
-    ],
-     build_args={
+    docker_build('webhook-server', '.', dockerfile = './Dockerfile.hotReload.tilt',
+        build_args={
             "BUILD_ENVIRONMENT":"staging",
             "WEBHOOK_VERSION":"0.0.1",
-        })
+        }
+    )
 
 
-    docker_build('datree/cluster-scanner-staging', '../cluster-scanner', dockerfile = '../cluster-scanner/Dockerfile',
-    build_args={
-        "BUILD_ENVIRONMENT":"staging",
-        "SCANNER_VERSION":"0.0.1",
-    })
+    docker_build('datree/cluster-scanner-staging', '../cluster-scanner', dockerfile = '../cluster-scanner/Dockerfile.hotReload.tilt',
+        build_args={
+            "BUILD_ENVIRONMENT":"staging",
+            "SCANNER_VERSION":"0.0.1",
+        }
+    )
     
 
 if os.environ.get('TILT_ENV') == 'debugging':


### PR DESCRIPTION
- use the same hot reload for the webhook, as we have for the scanner (a bit slow, but at least it works)
performance is not the worst:
![image](https://github.com/datreeio/admission-webhook-datree/assets/39004075/e096d77c-9298-4a07-84a2-191a62884cf0)
